### PR TITLE
Improve table accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,9 @@
         <p>The following table lists the requirements at each stage of the workflow:</p>
         <p class="ednote">TODO: Add [[media-accessibility-reqs]]</p>
         <table class="simple">
-            <caption>Table of requirements, with each linked to the workflow process stages that generates it.</caption>
+            <caption>Table of requirements, each having a unique requirement number,
+              links to the workflow process stages from which it arises,
+              and a detailed description.</caption>
             <thead>
                 <tr>
                     <th scope="col">Requirement number</th>

--- a/index.html
+++ b/index.html
@@ -220,18 +220,19 @@
         <p>The following table lists the requirements at each stage of the workflow:</p>
         <p class="ednote">TODO: Add [[media-accessibility-reqs]]</p>
         <table class="simple">
+            <caption>Table of requirements, with each linked to the workflow process stages that generates it.</caption>
             <thead>
                 <tr>
-                    <th colspan="1" rowspan="1">Requirement number</th>
-                    <th colspan="1" rowspan="1">Process step</th>
-                    <th colspan="1" rowspan="1">Requirement</th>
+                    <th scope="col">Requirement number</th>
+                    <th scope="col">Process step</th>
+                    <th scope="col">Requirement</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td colspan="1" rowspan="1">R1</td>
-                    <td colspan="1" rowspan="1">all</td>
-                    <td colspan="1" rowspan="1"><p>A document shall identify the type of document it corresponds to,
+                    <td>R1</td>
+                    <td>all</td>
+                    <td><p>A document shall identify the type of document it corresponds to,
                         from typical dubbing and audio description workflows,
                         at least among:
                         &quot;Audio Description Script&quot;,
@@ -243,9 +244,9 @@
                         &quot;As-recorded Audio Description Script&quot;.</p></td>
                     </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R2</td>
-                    <td colspan="1" rowspan="1"><a>PS1</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to define a list of intervals,
+                    <td>R2</td>
+                    <td><a>PS1</a></td>
+                    <td><p>A document must be able to define a list of intervals,
                         each called <dfn>event</dfn>,
                         defined by a begin time and an end time,
                         either matching a dialogue spoken by a single character or matching on-screen text from the programme,
@@ -255,24 +256,24 @@
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R3</td>
-                    <td colspan="1" rowspan="1"><a>PS2a</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to incorporate description text to be voiced,
+                    <td>R3</td>
+                    <td><a>PS2a</a></td>
+                    <td><p>A document must be able to incorporate description text to be voiced,
                         each description located within a timed interval defined by a begin time and an end time.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R4</td>
-                    <td colspan="1" rowspan="1"><a>PS2a</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to incorporate additional user defined metadata
+                    <td>R4</td>
+                    <td><a>PS2a</a></td>
+                    <td><p>A document must be able to incorporate additional user defined metadata
                         associated with each description;
                         metadata schemes may be user defined or centrally defined.
                         For example the language of the description may be stored,
                         or notes made by the script writer.</p></td>
                     </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R5</td>
-                    <td colspan="1" rowspan="1"><a>PS2a</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be extensible to allow incorporation of data required
+                    <td>R5</td>
+                    <td><a>PS2a</a></td>
+                    <td><p>A document must be extensible to allow incorporation of data required
                         to achieve the desired quality of audio presentation,
                         whether manual or automated.
                         For example it is typical to include information about
@@ -282,55 +283,55 @@
                         The format of any extensions for this purpose need not be defined.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R6</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to describe the characters participating in a programme,
+                    <td>R6</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able to describe the characters participating in a programme,
                         defined by a name in the programme,
                         optionally a name in the real world
                         and optional private metadata (e.g. images, text).</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R7</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate a unique character with a given <a>event</a>,
+                    <td>R7</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able to associate a unique character with a given <a>event</a>,
                         when the event corresponds to a dialogue.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R8</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate text content,
+                    <td>R8</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able to associate text content,
                         called <dfn>original content</dfn>,
                         with each <a>event</a>,
                         corresponding to the content of the dialogue or on-screen text.
                         The language shall be identified too.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R9</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate optional rendering styles with a character.</p></td>
+                    <td>R9</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able to associate optional rendering styles with a character.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R10</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document shall support associating rendering styles with an <a>event</a>.</p></td>
+                    <td>R10</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document shall support associating rendering styles with an <a>event</a>.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R11</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to optionally associate a human-readable string with an <a>event</a>,
+                    <td>R11</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able to optionally associate a human-readable string with an <a>event</a>,
                         providing annotation of the event.</p></td>
                     </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R12</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able, for an <a>event</a> corresponding to a dialogue,
+                    <td>R12</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document must be able, for an <a>event</a> corresponding to a dialogue,
                         to optionally indicate if the character is in the picture,
                         out of the picture or transitioning in or out of the picture.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R13</td>
-                    <td colspan="1" rowspan="1"><a>PS2b</a></td>
-                    <td colspan="1" rowspan="1"><p>A document shall support optionally annotating each <a>event</a>
+                    <td>R13</td>
+                    <td><a>PS2b</a></td>
+                    <td><p>A document shall support optionally annotating each <a>event</a>
                         with an indication of the type of event
                         (e.g. when the event corresponds to on-screen text,
                         if the text corresponds to &quot;Credits&quot; or &quot;Title&quot;;
@@ -338,54 +339,54 @@
                         and optionally additional human readable text.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R14</td>
-                    <td colspan="1" rowspan="1"><a>PS2c</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to optionally associate with an <a>event</a>
+                    <td>R14</td>
+                    <td><a>PS2c</a></td>
+                    <td><p>A document must be able to optionally associate with an <a>event</a>
                         a translation of the <a>original content</a> in a different, identified language.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R15</td>
-                    <td colspan="1" rowspan="1"><a>PS3</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to reference audio tracks either
+                    <td>R15</td>
+                    <td><a>PS3</a></td>
+                    <td><p>A document must be able to reference audio tracks either
                         included as binary data within the document
                         or separately.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R16</td>
-                    <td colspan="1" rowspan="1"><a>PS3</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate a begin time
+                    <td>R16</td>
+                    <td><a>PS3</a></td>
+                    <td><p>A document must be able to associate a begin time
                         with the beginning of playback of each audio track,
                         for the case that multiple audio tracks are created,
                         one per description.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R17</td>
-                    <td colspan="1" rowspan="1"><a>PS3</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate a begin time with a playback entry time
+                    <td>R17</td>
+                    <td><a>PS3</a></td>
+                    <td><p>A document must be able to associate a begin time with a playback entry time
                         within an audio track,
                         for the case that a single audio track is generated
                         that contains multiple segments of audio to be played back at different times.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R18</td>
-                    <td colspan="1" rowspan="1"><a>PS4</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to associate a left/right pan value
+                    <td>R18</td>
+                    <td><a>PS4</a></td>
+                    <td><p>A document must be able to associate a left/right pan value
                         with playback of each or every audio description.
                         This value applies to the audio description prior to mixing with the main programme audio.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R19</td>
-                    <td colspan="1" rowspan="1"><a>PS4</a></td>
-                    <td colspan="1" rowspan="1"><p>A document must be able to define a fade level curve
+                    <td>R19</td>
+                    <td><a>PS4</a></td>
+                    <td><p>A document must be able to define a fade level curve
                         that applies to the main programme audio prior to mixing with the audio description,
                         where that fade level curve is defined by
                         a set of pairs of level and times
                         and an interpolation algorithm.</p></td>
                 </tr>
                 <tr>
-                    <td colspan="1" rowspan="1">R20</td>
-                    <td colspan="1" rowspan="1">all</td>
-                    <td colspan="1" rowspan="1"><p>A document shall support storing private metadata associated with the document,
+                    <td>R20</td>
+                    <td>all</td>
+                    <td><p>A document shall support storing private metadata associated with the document,
                         such as a title,
                         an episode identifier,
                         a season identifier, etc.</p></td>


### PR DESCRIPTION
* Add scope attribute to each table header cell
* Add table caption
* Remove unnecessary `colspan` and `rowspan` attributes that were just set to 1, which is the default.

This addresses the remainder of #4 as far as I am aware.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dapt-reqs/pull/10.html" title="Last updated on Mar 30, 2022, 4:13 PM UTC (e77d628)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt-reqs/10/9112d5f...e77d628.html" title="Last updated on Mar 30, 2022, 4:13 PM UTC (e77d628)">Diff</a>