### PR TITLE
removed scrap text from visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,9 +74,9 @@
       <p>This document captures technical requirements for a profile of TTML2 for use
           in workflows related to dubbing and audio description of movies and videos.</p>
     </section>
-    <section id="sotd">
-      <p>This is required.</p>
-    </section>
+    <section id="sotd"><!--
+      This is required.
+    --></section>
     <section class="informative">
       <h2>Introduction</h2>
       <p>W3C members have identified the need for a profile of TTML for the exchange of timed text content


### PR DESCRIPTION
this line should be omitted from the real SoTD.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/dapt-reqs/pull/11.html" title="Last updated on Apr 1, 2022, 7:02 AM UTC (feb548b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dapt-reqs/11/0b90d6a...himorin:feb548b.html" title="Last updated on Apr 1, 2022, 7:02 AM UTC (feb548b)">Diff</a>