### PR TITLE
[DO NOT MERGE NOW] added GHAction for streamlined publication

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,27 @@
+name: Build, and publish spec to GitHub Pages and /TR/
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+    paths:
+      - 'figures/**'
+      - 'index.html'
+
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: index.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
+          W3C_WG_DECISION_URL: https://www.w3.org/2022/03/17-tt-minutes.html#r02
+          W3C_BUILD_OVERRIDE: |
+            specStatus: DNOTE
+
+# not set 'warning' to BUILD_FAIL_ON (not to cause error by bikeshed warning?)
+


### PR DESCRIPTION
Merge this after publication as first published DNOTE to /TR/ (might be 12/Apr), after approval of transition (might be 7-8/Apr?) which will happen after approval of WG charter extension for 3mo (might be next Wed - 6/Apr?).